### PR TITLE
Resolve kaminari gem dependency

### DIFF
--- a/paginatable.gemspec
+++ b/paginatable.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
 
-  spec.add_dependency 'kaminari', '~> 0.16.0'
+  spec.add_dependency 'kaminari', '=> 0.16.0'
   spec.add_dependency 'activesupport'
 end


### PR DESCRIPTION
Dependency version of kaminari gem is locked to `~> 1.6.0` which prevents from using activesupport higher than `= 3.0.0`. Changing it to `=> 1.6.0`.